### PR TITLE
used get-azresource to get vmss by full id

### DIFF
--- a/AzureBasicLoadBalancerUpgrade/AzureBasicLoadBalancerUpgrade.psd1
+++ b/AzureBasicLoadBalancerUpgrade/AzureBasicLoadBalancerUpgrade.psd1
@@ -12,7 +12,7 @@
     RootModule = 'AzureBasicLoadBalancerUpgrade'
 
     # Version number of this module.
-    ModuleVersion = '0.1.1'
+    ModuleVersion = '0.1.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/AzureBasicLoadBalancerUpgrade/modules/BackupBasicLoadBalancer/BackupBasicLoadBalancer.psd1
+++ b/AzureBasicLoadBalancerUpgrade/modules/BackupBasicLoadBalancer/BackupBasicLoadBalancer.psd1
@@ -12,7 +12,7 @@
 RootModule = 'BackupBasicLoadBalancer'
 
 # Version number of this module.
-ModuleVersion = '0.1.0'
+ModuleVersion = '0.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/AzureBasicLoadBalancerUpgrade/modules/BackupBasicLoadBalancer/BackupBasicLoadBalancer.psm1
+++ b/AzureBasicLoadBalancerUpgrade/modules/BackupBasicLoadBalancer/BackupBasicLoadBalancer.psm1
@@ -93,13 +93,14 @@ function BackupBasicLoadBalancer {
     }
 
     # Backup VMSS Object
-    $vmssIds = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object { $_.split("virtualMachines")[0] } | Select-Object -Unique
+    $vmssIds = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object { $_.split("/virtualMachines/")[0] } | Select-Object -Unique
     foreach ($vmssId in $vmssIds) {
-        $vmssName = $vmssId.split("/")[8]
-        $vmssRg = $vmssId.Split('/')[4]
+        $message = "[BackupBasicLoadBalancer] Attempting to create a file-based backup VMSS with id '$vmssId'"
+        log -Severity Information -Message $message
+
         try {
             $ErrorActionPreference = 'Stop'
-            $vmss = Get-AzVmss -ResourceGroupName $vmssRg -VMScaleSetName $vmssName
+            $vmss = Get-AzResource -ResourceId $vmssId | Get-AzVmss -ResourceGroupName $vmssRg -VMScaleSetName $vmssName
             $outputFileNameVMSS = ('VMSS_' + $vmss.Name + "_" + $vmss.ResourceGroupName + "_" + $backupDateTime + ".json")
             $outputFilePathVSS = Join-Path -Path $RecoveryBackupPath -ChildPath $outputFileNameVMSS
 

--- a/AzureBasicLoadBalancerUpgrade/modules/GetVMSSFromBasicLoadBalancer/GetVMSSFromBasicLoadBalancer.psd1
+++ b/AzureBasicLoadBalancerUpgrade/modules/GetVMSSFromBasicLoadBalancer/GetVMSSFromBasicLoadBalancer.psd1
@@ -12,7 +12,7 @@
 RootModule = 'GetVMSSFromBasicLoadBalancer'
 
 # Version number of this module.
-ModuleVersion = '0.1.0'
+ModuleVersion = '0.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/AzureBasicLoadBalancerUpgrade/modules/GetVMSSFromBasicLoadBalancer/GetVMSSFromBasicLoadBalancer.psm1
+++ b/AzureBasicLoadBalancerUpgrade/modules/GetVMSSFromBasicLoadBalancer/GetVMSSFromBasicLoadBalancer.psm1
@@ -9,11 +9,10 @@ function GetVMSSFromBasicLoadBalancer {
 
     try {
         $ErrorActionPreference = 'Stop'
-        $vmssId = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object { $_.split("virtualMachines")[0] } | Select-Object -Unique
-        $vmssRg = $vmssId.Split('/')[4]
-        $vmssName = $vmssId.Split('/')[8]
-        log -Message "[GetVMSSFromBasicLoadBalancer] Loading VMSS $vmssName from RG $vmssRg"
-        $vmss = Get-AzVmss -ResourceGroupName $vmssRg -VMScaleSetName $vmssName
+        $vmssId = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object { $_.split("/virtualMachines/")[0] } | Select-Object -Unique
+
+        log -Message "[GetVMSSFromBasicLoadBalancer] Getting VMSS object '$vmssId' from Azure"
+        $vmss = Get-AzResource -ResourceId $vmssId | Get-AzVmss
     }
     catch {
         $message = @"

--- a/AzureBasicLoadBalancerUpgrade/modules/NSGCreation/NSGCreation.psd1
+++ b/AzureBasicLoadBalancerUpgrade/modules/NSGCreation/NSGCreation.psd1
@@ -12,7 +12,7 @@
 RootModule = 'NSGCreation'
 
 # Version number of this module.
-ModuleVersion = '0.1.0'
+ModuleVersion = '0.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/AzureBasicLoadBalancerUpgrade/modules/NSGCreation/NSGCreation.psm1
+++ b/AzureBasicLoadBalancerUpgrade/modules/NSGCreation/NSGCreation.psm1
@@ -10,11 +10,10 @@ function NSGCreation {
     log -Message "[NSGCreation] Initiating NSG Creation"
 
     log -Message "[NSGCreation] Looping all VMSS in the backend pool of the Load Balancer"
-    $vmssIds = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object { $_.split("virtualMachines")[0] } | Select-Object -Unique
+    $vmssIds = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object { $_.split("/virtualMachines/")[0] } | Select-Object -Unique    
+    
     foreach ($vmssId in $vmssIds) {
-        $vmssName = $vmssId.split("/")[8]
-        $vmssRg = $vmssId.Split('/')[4]
-        $vmss = Get-AzVmss -ResourceGroupName $vmssRg -VMScaleSetName $vmssName
+        $vmss = Get-AzResource -ResourceId $vmssId | Get-AzVmss
 
         # Check if VMSS already has a NSG
         log -Message "[NSGCreation] Checking if VMSS Named: $($vmss.Name) has a NSG"

--- a/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.psd1
+++ b/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ValidateScenario'
 
 # Version number of this module.
-ModuleVersion = '0.1.0'
+ModuleVersion = '0.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.psm1
+++ b/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.psm1
@@ -49,7 +49,7 @@ Function Test-SupportedMigrationScenario {
     # Basic Load Balancers doesn't allow more than one VMSS as a backend pool becuase they would be under different availability sets.
     # This is a sanity check to make sure that the script is not run on a Basic Load Balancer that has more than one VMSS in the backend pool.
     log -Message "[Test-SupportedMigrationScenario] Checking if there are more than one VMSS in the backend pool"
-    $vmssIds = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object { $_.split("virtualMachines")[0] } | Select-Object -Unique
+    $vmssIds = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object { $_.split("/virtualMachines/")[0] } | Select-Object -Unique
     if ($vmssIds.count -gt 1) {
         log -ErrorAction Stop -Message "[Test-SupportedMigrationScenario] Basic Load Balancer has more than one VMSS in the backend pool, exiting" -Severity 'Error'
         return
@@ -78,7 +78,7 @@ Function Test-SupportedMigrationScenario {
 
     # check if load balancer backend pool contains VMSSes which are part of another LBs backend pools
     log -Message "[Test-SupportedMigrationScenario] Checking if backend pools contain members which are members of another load balancer's backend pools..."
-    $vmssIds = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object{$_.split("virtualMachines")[0]} | Select-Object -Unique
+    $vmssIds = $BasicLoadBalancer.BackendAddressPools.BackendIpConfigurations.id | Foreach-Object{$_.split("/virtualMachines/")[0]} | Select-Object -Unique
     ForEach ($vmssId in $vmssIds) {
         $vmss = Get-AzResource -ResourceId $vmssId | Get-AzVMSS
         $loadBalancerAssociations = @()


### PR DESCRIPTION
The Get-AzVMSS command currently permits blank values for parameters which it then treats as wildcards. For example, running Get-AzVMSS -ResourceGroupName '' -VMScaleSetName '' returns all scale sets in the subscription. In a scenario where an invalid resource ID is used for these parameter values, this could have unintended consequences. 

Switched to passing the full resource ID to Get-AzResource and piping that to Get-AzVmss for a more consistent experience. Get-AzResource does not permit array values in -ResourceId. 

#6 