### PR TITLE
Prompt for Internal LBs with no Public IPs

### DIFF
--- a/AzureBasicLoadBalancerUpgrade/AzureBasicLoadBalancerUpgrade.psd1
+++ b/AzureBasicLoadBalancerUpgrade/AzureBasicLoadBalancerUpgrade.psd1
@@ -12,7 +12,7 @@
     RootModule = 'AzureBasicLoadBalancerUpgrade'
 
     # Version number of this module.
-    ModuleVersion = '0.1.2'
+    ModuleVersion = '0.1.3'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ An Azure PowerShell module is available to upgrade from Basic load balancer to a
 - Basic load balancers with IPV6 frontend IP configurations
 - Basic load balancers with a VMSS backend pool member configured with 'Flexible' orchestration mode
 - Basic load balancers with a VMSS backend pool member where one or more VMSS instances have ProtectFromScaleSetActions Instance Protection policies enabled
+- Basic load balancers with a Public IP Configuration in the associated VMSS's network profile
 - Migrating a Basic load balancer to an existing Standard load balancer
 
 ### Prerequisites

--- a/testEnvs/modules/Microsoft.Compute/virtualMachineScaleSets/deploy.bicep
+++ b/testEnvs/modules/Microsoft.Compute/virtualMachineScaleSets/deploy.bicep
@@ -351,7 +351,7 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2021-04-01' = {
+resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2022-03-01' = {
   name: name
   location: location
   tags: tags

--- a/testEnvs/scenarios/026-basic-lb-int-vm-pips-basic.bicep
+++ b/testEnvs/scenarios/026-basic-lb-int-vm-pips-basic.bicep
@@ -1,0 +1,150 @@
+targetScope = 'subscription'
+param location string
+param resourceGroupName string
+param keyVaultName string
+param keyVaultResourceGroupName string
+
+// Resource Group
+module rg '../modules/Microsoft.Resources/resourceGroups/deploy.bicep' = {
+  name: resourceGroupName
+  params: {
+    name: resourceGroupName
+    location: location
+  }
+}
+
+// vnet
+module virtualNetworks '../modules/Microsoft.Network/virtualNetworks/deploy.bicep' = {
+  name: '${uniqueString(deployment().name)}-virtualNetworks'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    // Required parameters
+    location: location
+    addressPrefixes: [
+      '10.0.0.0/16'
+    ]
+    name: 'vnet-01'
+    subnets: [
+      {
+        name: 'subnet-01'
+        addressPrefix: '10.0.1.0/24'
+      }
+    ]
+  }
+  dependsOn: [
+    rg
+  ]
+}
+
+// basic lb
+module loadbalancer '../modules/Microsoft.Network/loadBalancers/deploy.bicep' = {
+  name: 'lb-basic-01'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    name: 'lb-basic-01'
+    location: location
+    frontendIPConfigurations: [
+      {
+        name: 'fe-01'
+        subnetId: virtualNetworks.outputs.subnetResourceIds[0]
+      }
+    ]
+    backendAddressPools: [
+      {
+        name: 'be-01'
+      }
+    ]
+    inboundNatRules: []
+    loadBalancerSku: 'Basic'
+    loadBalancingRules: [
+      {
+        backendAddressPoolName: 'be-01'
+        backendPort: 80
+        frontendIPConfigurationName: 'fe-01'
+        frontendPort: 80
+        idleTimeoutInMinutes: 4
+        loadDistribution: 'Default'
+        name: 'rule-01'
+        probeName: 'probe-01'
+        protocol: 'Tcp'
+      }
+    ]
+    probes: [
+      {
+        intervalInSeconds: 5
+        name: 'probe-01'
+        numberOfProbes: 2
+        port: '80'
+        protocol: 'Tcp'
+      }
+    ]
+  }
+  dependsOn: [
+    rg
+  ]
+}
+
+resource kv1 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+  name: keyVaultName
+  scope: resourceGroup(keyVaultResourceGroupName)
+}
+
+module virtualMachineScaleSets '../modules/Microsoft.Compute/virtualMachineScaleSets/deploy.bicep' = {
+  name: 'vmss-01'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    location: location
+    // Required parameters
+    encryptionAtHost: false
+    adminUsername: kv1.getSecret('adminUsername')
+    skuCapacity: 1
+    upgradePolicyMode: 'Manual'
+    imageReference: {
+      offer: 'WindowsServer'
+      publisher: 'MicrosoftWindowsServer'
+      sku: '2022-Datacenter'
+      version: 'latest'
+    }
+    name: 'vmss-01'
+    osDisk: {
+      createOption: 'fromImage'
+      diskSizeGB: '128'
+      managedDisk: {
+        storageAccountType: 'Standard_LRS'
+      }
+    }
+    osType: 'Windows'
+    skuName: 'Standard_DS1_v2'
+    // Non-required parameters
+    adminPassword: kv1.getSecret('adminPassword')
+    nicConfigurations: [
+      {
+        ipConfigurations: [
+          {
+            name: 'ipconfig1'
+            properties: {
+              subnet: {
+                id: virtualNetworks.outputs.subnetResourceIds[0]
+              }
+              loadBalancerBackendAddressPools: [
+                {
+                  id: loadbalancer.outputs.backendpools[0].id
+                }
+              ]
+              publicIPAddressConfiguration: {
+                name: 'pipconfig1'
+                sku: {
+                  name: 'Basic'
+                }
+              }
+            }
+          }
+        ]
+        nicSuffix: '-nic-01'
+      }
+    ]
+  }
+  dependsOn: [
+    rg
+  ]
+}


### PR DESCRIPTION
1. Internal LBs where VMs do not have assigned public IP addresses will have no outbound internet access post migration due to SNAT behavior change between Basic and Standard LBs. Prompt the user to confirm and acknowledge that they will need to add a NAT Gateway or public IP configuration post migration.
2. Add VMSSes with PublicIPConfigurations to unsupported migration scenarios because the assigned PIPs will be basic and would conflict with the Standard LB PIPs post-migration. Support to automate removing and readding the PIP configuration post migration could be added

![image](https://user-images.githubusercontent.com/25390936/205132886-c9635711-50bb-4a9a-aa6a-058e4f3ae455.png)

![image](https://user-images.githubusercontent.com/25390936/205132350-429a7cb6-088a-4b1c-bd5f-d8aa704c0540.png)
