### PR TITLE
fix import-module / function call for UpdateVMSS/ UpdateVmss on cloud shell / linux

### DIFF
--- a/AzureBasicLoadBalancerUpgrade/modules/BackendPoolMigration/BackendPoolMigration.psm1
+++ b/AzureBasicLoadBalancerUpgrade/modules/BackendPoolMigration/BackendPoolMigration.psm1
@@ -133,7 +133,7 @@ function BackendPoolMigration {
     _MigrateNetworkInterfaceConfigurations -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancer $StdLoadBalancer -vmss $vmss
 
     # Update VMSS on Azure
-    UpdateVMSS -vmss $vmss
+    UpdateVmss -vmss $vmss
 
     # Update Instances
     UpdateVmssInstances -vmss $vmss
@@ -142,7 +142,7 @@ function BackendPoolMigration {
     _RestoreUpgradePolicyMode -vmss $vmss -refVmss $refVmss
 
     # Update VMSS on Azure
-    UpdateVMSS -vmss $vmss
+    UpdateVmss -vmss $vmss
 
     #log -Message "[BackendPoolMigration] Updating VMSS Instances $($vmss.Name)"
     #UpdateVmssInstances -vmss $vmss

--- a/AzureBasicLoadBalancerUpgrade/modules/BackendPoolMigration/BackendPoolMigration.psm1
+++ b/AzureBasicLoadBalancerUpgrade/modules/BackendPoolMigration/BackendPoolMigration.psm1
@@ -1,6 +1,6 @@
 # Load Modules
 Import-Module ((Split-Path $PSScriptRoot -Parent) + "\Log\Log.psd1")
-Import-Module ((Split-Path $PSScriptRoot -Parent) + "\UpdateVmss\UpdateVmss.psd1")
+Import-Module ((Split-Path $PSScriptRoot -Parent) + "\UpdateVMSS\UpdateVMSS.psd1")
 Import-Module ((Split-Path $PSScriptRoot -Parent) + "\UpdateVmssInstances\UpdateVmssInstances.psd1")
 Import-Module ((Split-Path $PSScriptRoot -Parent) + "\GetVMSSFromBasicLoadBalancer\GetVMSSFromBasicLoadBalancer.psd1")
 


### PR DESCRIPTION
from https://shell.azure.com / cloud shell, unable to run AzLoadBalancerMigration completely.
There is an error calling 'UpdateVMSS'
Function name is 'UpdateVmss'

Actual fix is on the import-module file name case mismatch:

-Import-Module ((Split-Path $PSScriptRoot -Parent) + "\UpdateVMSS\UpdateVMSS.psd1")
+Import-Module ((Split-Path $PSScriptRoot -Parent) + "\UpdateVMSS\UpdateVMSS.psd1")

Error from log:
UpdateVMSS: The term 'UpdateVMSS' is not recognized as a name of a cmdlet, function, script file, or executable program.

Verified fix resolves issue