### PR TITLE
add timestamp to $outputMessage

### DIFF
--- a/AzureBasicLoadBalancerUpgrade/modules/Log/Log.psm1
+++ b/AzureBasicLoadBalancerUpgrade/modules/Log/Log.psm1
@@ -17,8 +17,9 @@ function log {
         $terminateOnError
     )
 
-    Add-Content -Path ("Start-AzBasicLoadBalancerUpgrade.log") -Value ((Get-Date -Format 'yyyy-MM-dd hh:mm:ss.ffff') + " " + "[$Severity] - " + $Message) -Force
-    $outputMessage = "[{0}]:{1}" -f $Severity,($Message -replace '\s\s+?','')
+    $timestamp = Get-Date -Format 'yyyy-MM-ddTHH:mm:sszz'
+    Add-Content -Path ("Start-AzBasicLoadBalancerUpgrade.log") -Value ($timestamp + " " + "[$Severity] - " + $Message) -Force
+    $outputMessage = "{0} [{1}]:{2}" -f $timestamp, $Severity,($Message -replace '\s\s+?','')
     If ($global:FollowLog) {
         switch ($severity) {
             "Error" {


### PR DESCRIPTION
add timestamp with date, time, seconds , timezone.
adds same time to log and output

example:
2023-01-25T16:12:25+00 [Information]:############################## Initializing Start-AzBasicLoadBalancerUpgrade ##############################
2023-01-25T16:12:25+00 [Information]:[Start-AzBasicLoadBalancerUpgrade] Checking that user is signed in to Azure PowerShell
2023-01-25T16:12:25+00 [Information]:[Start-AzBasicLoadBalancerUpgrade] User is signed in to Azure with account, subscription 'Microsoft Azure Internal Consumption' selected
2023-01-25T16:12:25+00 [Information]:[Start-AzBasicLoadBalancerUpgrade] Loading Azure Resources
