### PR TITLE
add secondary NSG detection by subnet

### DIFF
--- a/AzureBasicLoadBalancerUpgrade/modules/NSGCreation/NSGCreation.psm1
+++ b/AzureBasicLoadBalancerUpgrade/modules/NSGCreation/NSGCreation.psm1
@@ -31,7 +31,7 @@ function NSGCreation {
             foreach ($subnetId in $subnetIds) {
                 $subnet = Get-AzResource -ResourceId $subnetId
                 if (![string]::IsNullOrEmpty($subnet.Properties.NetworkSecurityGroup)) {
-                    log -Message "[NSGCreation] NSG detected in VMSS Subnet Named: $($vmss.Name) Subnet.NetworkSecurityGroup Id: $($subnet.Properties.NetworkSecurityGroup.Id)" -severity "Warning"
+                    log -Message "[NSGCreation] NSG detected in Subnet for VMSS Named: $($vmss.Name) Subnet.NetworkSecurityGroup Id: $($subnet.Properties.NetworkSecurityGroup.Id)" -severity "Warning"
                     log -Message "[NSGCreation] NSG will not be created for VMSS Named: $($vmss.Name)" -severity "Warning"
                     $found = $true
                     break

--- a/AzureBasicLoadBalancerUpgrade/modules/NSGCreation/NSGCreation.psm1
+++ b/AzureBasicLoadBalancerUpgrade/modules/NSGCreation/NSGCreation.psm1
@@ -22,6 +22,25 @@ function NSGCreation {
             log -Message "[NSGCreation] NSG will not be created for VMSS Named: $($vmss.Name)" -severity "Warning"
             break
         }
+
+        # check vmss subnets for attached NSG's
+        if (![string]::IsNullOrEmpty($vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations.Ipconfigurations.Subnet)) {
+            $subnetIds = @($vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations.Ipconfigurations.Subnet.id)
+            $found = $false
+
+            foreach ($subnetId in $subnetIds) {
+                $subnet = Get-AzResource -ResourceId $subnetId
+                if (![string]::IsNullOrEmpty($subnet.Properties.NetworkSecurityGroup)) {
+                    log -Message "[NSGCreation] NSG detected in VMSS Subnet Named: $($vmss.Name) Subnet.NetworkSecurityGroup Id: $($subnet.Properties.NetworkSecurityGroup.Id)" -severity "Warning"
+                    log -Message "[NSGCreation] NSG will not be created for VMSS Named: $($vmss.Name)" -severity "Warning"
+                    $found = $true
+                    break
+                }
+            }
+            
+            if ($found) { break }
+        }
+
         log -Message "[NSGCreation] NSG not detected."
 
         log -Message "[NSGCreation] Creating NSG for VMSS: $vmssName"
@@ -70,10 +89,10 @@ function NSGCreation {
         $networkSecurityRuleConfig = $null
         $inboundNatRules = $BasicLoadBalancer.InboundNatRules
         foreach ($inboundNatRule in $inboundNatRules) {
-            if([string]::IsNullOrEmpty($inboundNatRule.FrontendPortRangeStart)){
+            if ([string]::IsNullOrEmpty($inboundNatRule.FrontendPortRangeStart)) {
                 $dstportrange = ($inboundNatRule.BackendPort).ToString()
             }
-            else{
+            else {
                 $dstportrange = (($inboundNatRule.FrontendPortRangeStart).ToString() + "-" + ($inboundNatRule.FrontendPortRangeEnd).ToString())
             }
             $networkSecurityRuleConfig = @{


### PR DESCRIPTION
some NSG's are only attached by subnet and not NIC.
add secondary check for NSG by subnet in fucntion NSGCreation()

example output:
2023-01-25T15:13:17-05 [Information] - [NSGCreation] Initiating NSG Creation
2023-01-25T15:13:17-05 [Information] - [NSGCreation] Looping all VMSS in the backend pool of the Load Balancer
2023-01-25T15:13:18-05 [Information] - [NSGCreation] Checking if VMSS Named: nt0 has a NSG
2023-01-25T15:13:20-05 [Warning] - [NSGCreation] NSG detected in Subnet for VMSS Named: nt0 Subnet.NetworkSecurityGroup Id: /subscriptions/.../resourceGroups/.../providers/Microsoft.Network/networkSecurityGroups/VNet-Subnet-0-nsg-eastus
2023-01-25T15:13:20-05 [Warning] - [NSGCreation] NSG will not be created for VMSS Named: nt0
2023-01-25T15:13:20-05 [Information] - [NSGCreation] NSG Creation Completed
