### PR TITLE
fix listsubresource empty error

### DIFF
--- a/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/AzureBasicLoadBalancerUpgrade.psd1
+++ b/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/AzureBasicLoadBalancerUpgrade.psd1
@@ -12,7 +12,7 @@
     RootModule = 'AzureBasicLoadBalancerUpgrade'
 
     # Version number of this module.
-    ModuleVersion = '2.3.3'
+    ModuleVersion = '2.3.4'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -107,7 +107,7 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = 'Fixed issue with creating a reference object of the VMSS, resulting inconsistent NAT Pool membership'
+            ReleaseNotes = 'Fix spurious error when calling _HardCopyObject when an IPConfig has no pool membership'
 
             # Prerelease string of this module
             # Prerelease = ''

--- a/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/BackendPoolMigration/BackendPoolMigration.psm1
+++ b/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/BackendPoolMigration/BackendPoolMigration.psm1
@@ -116,7 +116,9 @@ function _MigrateNetworkInterfaceConfigurationsVmss {
                 }
             }
             # Taking a hard copy of the object and assigning, it's important because the object was passed by reference
-            $ipConfiguration.LoadBalancerBackendAddressPools = _HardCopyObject -listSubResource $genericListSubResource
+            If ($genericListSubResource.Count -gt 0) {
+                $ipConfiguration.LoadBalancerBackendAddressPools = _HardCopyObject -listSubResource $genericListSubResource
+            }
             $genericListSubResource.Clear()
         }
     }


### PR DESCRIPTION
Issue in logs: 
![image](https://github.com/Azure/AzLoadBalancerMigration/assets/25390936/bc874bf9-046c-4628-8bd4-6701b607a645)

Issue caused by trying to call _hardCopyObject with an empty subresource list: 
![image](https://github.com/Azure/AzLoadBalancerMigration/assets/25390936/a7d15dfd-3d34-4483-8e70-4354cbd8c5a7)
