### PR TITLE
Added check for AKS clusters with basic a load balancer

### DIFF
--- a/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.Tests.ps1
+++ b/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.Tests.ps1
@@ -157,7 +157,7 @@ Describe "ValidateScenario" {
   }
 
   Context "Input Parameters" {
-    It "Should fail is an invalid Load Balancer name is supplied" {
+    It "Should fail if an invalid Load Balancer name is supplied" {
       $errMsg = "Cannot validate argument on parameter 'StdLoadBalancerName'.*"
       { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName '_' -ErrorAction Stop } | Should -Throw -ExpectedMessage $errMsg
     }
@@ -168,34 +168,61 @@ Describe "ValidateScenario" {
     }
   }
 
+  Context "Basic LoadBalancer used in AKS cluster" {
+    It "Should fail if the basic load balancer is used as an external LB by an AKS cluster (LB is named 'kubernetes')" {
+      $BasicLoadBalancer.Name = 'kubernetes'
+      $errMsg = "*is used by an AKS cluster & cannot be migrated*"
+      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage $errMsg
+    }
+
+    It "Should fail if the basic load balancer is used an an internal LB by an AKS cluster (LB is named 'kubernetes-internal')" {
+      $BasicLoadBalancer.Name = 'kubernetes-internal'
+      $errMsg = "*is used by an AKS cluster & cannot be migrated*"
+      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage $errMsg
+    }
+
+    It "Should fail if the basic load balancer is used an an internal LB by an AKS cluster (Azure System managed Tags)" {
+      $BasicLoadBalancer
+      $errMsg = "*is used by an AKS cluster & cannot be migrated*"
+      $BasicLoadBalancer.Tag.Add('aks-managed-cluster-name','mycluster')
+      $BasicLoadBalancer.Tag.Add('aks-managed-cluster-rg','mycluster-rg')
+      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage $errMsg
+    }
+  }
+
   Context "VMSS in BackendPools" {
     It "Should fail if the backend pool ip configuration does not contain 'VirtualMachineScaleSet'" {
+      $errMsg = '*Basic Load Balancer backend pools can contain only VMs or VMSSes*'
       $BasicLoadBalancer.BackendAddressPools[0].BackendIpConfigurations[0].Id = "/subscriptions/b2375b5f-8dab-4436-b87c-32bc7fdce5d0/resourceGroups/rg-001-basic-lb-int-single-fe/providers/Microsoft.Compute/banana/vmss-01/virtualMachines/0/networkInterfaces/vmss-01-nic-01configuration-0/ipConfigurations/ipconfig1"
-      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage "*Basic Load Balancer has backend pools that is not virtualMachineScaleSets, exiting"
+      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -ExpectedMessage $errMsg
     }
   }
 
   Context "Empty BackendPools" {
     It "Should fail if the backend pool(s) have no membership" {
-      $BasicLoadBalancer.BackendAddressPools[0].BackendIpConfigurations = @()
-      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage "*Basic Load Balancer has backend pools have no membership, exiting"
+      $errMsg = '*Basic Load Balancer backend pools are empty*'
+      $BasicLoadBalancer.Probes = $null
+      $BasicLoadBalancer.BackendAddressPools = $null
+      $BasicLoadBalancer.LoadBalancingRules = $null
+      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage $errMsg
     }
   }
 
   Context "LoadBalancingRules" {
     It "Should fail if no LoadBalancingRules exist on the load balancer" {
-      $BasicLoadBalancer.LoadBalancingRules = $null
-      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage "*Load balancer 'lb-basic-01' has no front end configurations, so there is nothing to migrate!"
+      $errMsg = "*Load balancer 'lb-basic-01' has no front end configurations, so there is nothing to migrate*"
+      $BasicLoadBalancer.LoadBalancingRules = @()
+      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage $errMsg
     }
   }
 
   Context "Public Ip Prefix" {
     It "Should fail if the Public IP has an IPPrefix" {
+      $errMsg = "*FrontEndIPConfiguration[0] is assigned a public IP prefix*"
       $ipPrefix = [Microsoft.Azure.Commands.Network.Models.PSResourceId]::new()
       $ipPrefix.Id = "/subscriptions/b2375b5f-8dab-4436-b87c-32bc7fdce5d0/resourceGroups/rg-001-basic-lb-int-single-fe/providers/Microsoft.Compute/banana/vmss-01/virtualMachines/0/networkInterfaces/vmss-01-nic-01configuration-0/ipConfigurations/ipconfig1"
       $BasicLoadBalancer.FrontendIpConfigurations[0].PublicIPPrefix = $ipPrefix
-      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage "*FrontEndIPConfiguration*"
+      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage $errMsg
     }
   }
-
 }

--- a/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.Tests.ps1
+++ b/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.Tests.ps1
@@ -198,16 +198,6 @@ Describe "ValidateScenario" {
     }
   }
 
-  Context "Empty BackendPools" {
-    It "Should fail if the backend pool(s) have no membership" {
-      $errMsg = '*Basic Load Balancer backend pools are empty*'
-      $BasicLoadBalancer.Probes = $null
-      $BasicLoadBalancer.BackendAddressPools = $null
-      $BasicLoadBalancer.LoadBalancingRules = $null
-      { Test-SupportedMigrationScenario -BasicLoadBalancer $BasicLoadBalancer -StdLoadBalancerName 'std-lb-01' -ErrorAction Stop } | Should -Throw -ExpectedMessage $errMsg
-    }
-  }
-
   Context "LoadBalancingRules" {
     It "Should fail if no LoadBalancingRules exist on the load balancer" {
       $errMsg = "*Load balancer 'lb-basic-01' has no front end configurations, so there is nothing to migrate*"

--- a/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.psm1
+++ b/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/ValidateScenario/ValidateScenario.psm1
@@ -1,7 +1,6 @@
 # Load Modules
 Import-Module ((Split-Path $PSScriptRoot -Parent) + "/Log/Log.psd1")
 Import-Module ((Split-Path $PSScriptRoot -Parent) + "/GetVmssFromBasicLoadBalancer/GetVmssFromBasicLoadBalancer.psd1")
-Import-Module Az.Network
 
 function _GetScenarioBackendType {
     param(
@@ -69,7 +68,7 @@ function _GetScenarioBackendType {
         $backendType = 'VMSS'
     }
     ElseIf ([string]::IsNullOrEmpty($backendMemberTypes[0])) {
-        log -ErrorAction Stop -Severity 'Error' -Message "[Test-SupportedMigrationScenario] Basic Load Balancer backend pools are empty"
+        log -Message "[Test-SupportedMigrationScenario] Basic Load Balancer backend pools are empty"
         $backendType = 'Empty'
     }
     Else {

--- a/AzureBasicLoadBalancerUpgrade/testEnvs/modules/aks/aks.bicep
+++ b/AzureBasicLoadBalancerUpgrade/testEnvs/modules/aks/aks.bicep
@@ -1,0 +1,42 @@
+param loadBalancerType string = 'bnasic'
+param location string
+param subnetId string
+param k8sVersion string
+param vmSize string
+
+var suffix = uniqueString(resourceGroup().id)
+
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2023-11-01' = {
+  name: 'aks-${suffix}'
+  location: location
+  sku: {
+    name: 'Base'
+    tier: 'Free'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    dnsPrefix: 'aks-${suffix}'
+    kubernetesVersion: k8sVersion
+    networkProfile: {
+      networkPlugin: 'azure'
+      loadBalancerSku: loadBalancerType
+      serviceCidr: '10.1.0.0/24'
+      dnsServiceIP: '10.1.0.10'
+    }
+    agentPoolProfiles: [
+      {
+        name: 'agentpool1'
+        count: 2
+        type: 'VirtualMachineScaleSets'
+        mode: 'System'
+        vnetSubnetID: subnetId
+        vmSize: vmSize
+        osType: 'Linux'
+        osSKU: 'Ubuntu'
+      }
+    ]
+  }
+}
+

--- a/AzureBasicLoadBalancerUpgrade/testEnvs/scenarios/115-aks-basic-lb.bicep
+++ b/AzureBasicLoadBalancerUpgrade/testEnvs/scenarios/115-aks-basic-lb.bicep
@@ -1,0 +1,51 @@
+targetScope = 'subscription'
+param location string
+param resourceGroupName string
+param vmSize string = 'Standard_D2_v2'
+
+// Resource Group
+module rg '../modules/Microsoft.Resources/resourceGroups/deploy.bicep' = {
+  name: '${resourceGroupName}-${location}'
+  params: {
+    name: resourceGroupName
+    location: location
+  }
+}
+
+// vnet
+module virtualNetworks '../modules/Microsoft.Network/virtualNetworks/deploy.bicep' = {
+  name: 'virtualNetworks-module'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    // Required parameters
+    location: location
+    addressPrefixes: [
+      '10.0.0.0/16'
+    ]
+    name: 'vnet-01'
+    subnets: [
+      {
+        name: 'subnet-01'
+        addressPrefix: '10.0.1.0/24'
+      }
+    ]
+  }
+  dependsOn: [
+    rg
+  ]
+}
+
+module aks '../modules/aks/aks.bicep' = {
+  name: 'aks-module'
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    k8sVersion: '1.28.3'
+    location: location
+    subnetId: virtualNetworks.outputs.subnetResourceIds[0]
+    vmSize: vmSize
+    loadBalancerType: 'basic'
+  }
+  dependsOn: [
+    virtualNetworks
+  ]
+}

--- a/AzureBasicLoadBalancerUpgrade/utilities/aks-ilb.yml
+++ b/AzureBasicLoadBalancerUpgrade/utilities/aks-ilb.yml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  #annotations:
+  #  service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  name: my-service
+  namespace: default
+spec:
+  ports:
+  - protocol: TCP
+    port: 60000
+  type: LoadBalancer
+  


### PR DESCRIPTION
Added checks for an AKS cluster with basic load balancer. If the load balancer is named 'kubernetes' or 'kubernetes-internal', the migration will exit.

When using a basic LB for AKS no LB is created at deploy time as cluster egress uses MS shared public IPs (default VM internet access approach). A Basic LB is only created when an operator deploys a Kubernetes service object with the Azure load balancer annotation and no tagging is applied to the Basic ALB/ILB by the platform, as is the case with a Standard Load Balancer.