### PR TITLE
Fix bad parameter for Recovering section command

### DIFF
--- a/AzureVMBasicPublicIPUpgrade/README.md
+++ b/AzureVMBasicPublicIPUpgrade/README.md
@@ -66,12 +66,12 @@ The Azure Powershell module must be installed. See [Install the latest Az PowerS
 
 When a migration fails due to a transient issue, such as a network outage or client system crash, the migration can be re-run to configure the VM and Public IPs in the goal state. At execution, the script outputs a recovery log file which is used to ensure the VM is properly reconfigured. Review the log file `PublicIPUpgrade.log` created in the location where the script was executed.
 
-To recover from a failed upgrade, pass the recovery log file path to the script with the `-recoverFromFile` parameter and identify the VM to recover with the `-VMName` and `-VMResourceGroup` or `-VMResourceID` parameters. 
+To recover from a failed upgrade, pass the recovery log file path to the script with the `-recoverFromFile` parameter and identify the VM to recover with the `-VMName` and `-ResourceGroupName` or `-VMResourceID` parameters. 
 
 **EXAMPLE: Recover from a failed migration, passing the name and resource group of the VM to recover, along with the recovery log file**
 
 ```powershell
-    Start-VMPublicIPUpgrade -RecoverFromFile ./PublicIPUpgrade_Recovery_2020-01-01-00-00.csv -VMName myVM -VMResourceGroup -rg-myrg
+    Start-VMPublicIPUpgrade -RecoverFromFile ./PublicIPUpgrade_Recovery_2020-01-01-00-00.csv -VMName 'myVM' -ResourceGroupName 'myRG'
 ```
 
 ## Frequently Asked Questions


### PR DESCRIPTION
This pull request updates the `README.md` file in the `AzureVMBasicPublicIPUpgrade` module to clarify parameter usage for recovering from a failed upgrade. The change ensures consistency in naming conventions and improves readability.

Documentation updates:

* [`AzureVMBasicPublicIPUpgrade/README.md`](diffhunk://#diff-e0f025bb7bb93f713a736220ee9b0f5ad7ef262ef68cd287474f944ba06cd9a0L69-R74): Replaced `-VMResourceGroup` with `-ResourceGroupName` in the recovery instructions and example command to align with standard Azure parameter naming conventions.

The parameter showed in the example isn't correct for the recovering command :
![image](https://github.com/user-attachments/assets/720d59ef-5589-46dc-b9f4-9c72d39c9412)