### PR TITLE
fix parameter typo. Activity already specified in @progressParams

### DIFF
--- a/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/ScenariosMigration/ScenariosMigration.psm1
+++ b/AzureBasicLoadBalancerUpgrade/module/AzureBasicLoadBalancerUpgrade/modules/ScenariosMigration/ScenariosMigration.psm1
@@ -117,7 +117,7 @@ function PublicLBMigrationVmss {
     RemoveVmssPublicIPConfig -BasicLoadBalancer $BasicLoadBalancer
 
     # Migrate public IP addresses on Basic LB to static (if dynamic)
-    Write-Progress -Activity "Migrating public IP addresses on Basic LB to static (if dynamic)" -PercentComplete ((2 / 14) * 100) @progressParams
+    Write-Progress -Status "Migrating public IP addresses on Basic LB to static (if dynamic)" -PercentComplete ((2 / 14) * 100) @progressParams
     PublicIPToStatic -BasicLoadBalancer $BasicLoadBalancer
     
     # Add Public IP Configurations to VMSS (with Standard SKU)


### PR DESCRIPTION
fix logging error:
Write-Progress : Cannot bind parameter because parameter 'Activity' is specified more than once.
To provide multiple values to parameters that can accept multiple values,
use the array syntax. For example, "-parameter value1,value2,value3".
At C:\Users\ali\Documents\WindowsPowerShell\Modules\AzureBasicLoadBalancerUpgrade\2.4.15\modules\ScenariosMigration\ScenariosMigration.psm1:120 char:131
static (if dynamic)" -PercentComplete ((2 / 14) * 100) @progressParams ~~~~~~~~~~~~~~~
CategoryInfo : InvalidArgument: (:) [Write-Progress], ParameterBindingException
FullyQualifiedErrorId : ParameterAlreadyBound,Microsoft.PowerShell.Commands.WriteProgressCommand

```powershell
 $progressParams = @{
        Activity = "Migrating basic load balancer '$($BasicLoadBalancer.Name)'"
        ParentId = 4
    }

    Write-Progress -Status "Public Load Balancer with VMSS backend detected. Initiating Public Load Balancer Migration" -PercentComplete 0 @progressParams
    log -Message "[PublicLBMigration] Public Load Balancer with VMSS backend found. Initiating Public Load Balancer Migration"

    # Remove Public IP Configurations from VMSS
    Write-Progress -Status "Removing Public IP Configurations from VMSS" -PercentComplete ((1 / 14) * 100) @progressParams
    RemoveVmssPublicIPConfig -BasicLoadBalancer $BasicLoadBalancer

    # Migrate public IP addresses on Basic LB to static (if dynamic)
    Write-Progress -Status "Migrating public IP addresses on Basic LB to static (if dynamic)" -PercentComplete ((2 / 14) * 100) @progressParams
    PublicIPToStatic -BasicLoadBalancer $BasicLoadBalancer
 ```